### PR TITLE
Support DICOM files without the 'File Meta Information Group Length' tag

### DIFF
--- a/src/Message.ts
+++ b/src/Message.ts
@@ -148,7 +148,7 @@ export default class DicomMessage {
     if (el.tag.value == 0x00020000) {
       metaLength = el.values[0];
     // No Length but there are metadata tags
-    } else if (el.tag.value>>16 == 2) {
+    } else if ((el.tag.value & 0xFFFF0000) === 0x00020000) {
       console.warn("Warning: missing File Meta Information Group Length! (0002,0000)");
 
       // Try to calculate the size of the metadata block by reading all (0002,xxxx) tags

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -142,7 +142,7 @@ export default class DicomMessage {
     }
     var el = DicomMessage.readTag(stream, useSyntax);
 
-    var metaLength
+    var metaLength;
 
     // File Meta Information Group Length is correctly suplied
     if (el.tag.value == 0x00020000) {

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -157,7 +157,7 @@ export default class DicomMessage {
         metaLength = stream.offset-128-4;
 
         var isMetaTag = DicomMessage.readTag(stream, useSyntax);
-        if (isMetaTag.tag.value>>16 != 2) {
+        if ((isMetaTag.tag.value & 0xFFFF0000) !== 0x00020000) {
           // Rewind the stream to the start of the metadata
           stream.reset();
           stream.increment(128+4);


### PR DESCRIPTION
Fix for [#5145 Certain DICOMs failing to upload; all images considered invalid](https://github.com/radiopaedia/Radiopaedia/issues/5145).

In a nutshell, the anonymiser heavily relies on the (0002,0000) File Meta Information Group Length tag being present for reading the DICOM metadata, and fails where some metadata is supplied but not the length. It is possible to "guess" the metadata block size (all metadata tags are from the group `0002`), and this PR implements that.